### PR TITLE
ko: Use apko v0.1.2 as base image

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,4 +1,4 @@
-defaultBaseImage: gcr.io/distroless/base-debian10
+defaultBaseImage: ghcr.io/chainguard-dev/apko:v0.1.2@sha256:5504f2a95018e3d8a52d80d9e1a128c6ea337581808ff9fe96f5628ce2336350
 
 builds:
 - id: peribolos


### PR DESCRIPTION
cc: @cpanato 
Signed-off-by: Stephen Augustus <foo@auggie.dev>