### PR TITLE
Allow local runs and simulating GitHub Actions environment

### DIFF
--- a/main.go
+++ b/main.go
@@ -45,6 +45,7 @@ const (
 )
 
 type options struct {
+	actions           bool
 	config            string
 	confirm           bool
 	dump              string
@@ -73,147 +74,161 @@ type options struct {
 
 func parseOptions() options {
 	var o options
-
 	if err := o.parseArgs(flag.CommandLine, os.Args[1:]); err != nil {
 		logrus.Fatalf("Invalid flags: %v", err)
 	}
-
-	o.dump = actions.GetInput("dump")
-	o.config = actions.GetInput("config-path")
-
-	dumpFull := actions.GetInput("dump-full")
-	if dumpFull != "" {
-		o.dumpFull, _ = strconv.ParseBool(dumpFull)
-	}
-
-	confirm := actions.GetInput("confirm")
-	if confirm != "" {
-		o.confirm, _ = strconv.ParseBool(confirm)
-	}
-
-	o.github.TokenPath = actions.GetInput("github-token-path")
-	if o.github.TokenPath == "" {
-		actions.Fatalf("missing 'github-token-path'")
-	}
-
-	fixOrg := actions.GetInput("fix-org")
-	if fixOrg != "" {
-		o.fixOrg, _ = strconv.ParseBool(fixOrg)
-	}
-
-	fixOrgMembers := actions.GetInput("fix-org-members")
-	if fixOrgMembers != "" {
-		o.fixOrgMembers, _ = strconv.ParseBool(fixOrgMembers)
-	}
-
-	fixTeams := actions.GetInput("fix-teams")
-	if fixTeams != "" {
-		o.fixTeams, _ = strconv.ParseBool(fixTeams)
-	}
-
-	fixTeamMembers := actions.GetInput("fix-teams-members")
-	if fixTeamMembers != "" {
-		o.fixTeamMembers, _ = strconv.ParseBool(fixTeamMembers)
-	}
-
-	fixTeamRepos := actions.GetInput("fix-team-repos")
-	if fixTeamRepos != "" {
-		o.fixTeamRepos, _ = strconv.ParseBool(fixTeamRepos)
-	}
-
-	fixRepos := actions.GetInput("fix-repos")
-	if fixRepos != "" {
-		o.fixRepos, _ = strconv.ParseBool(fixRepos)
-	}
-
-	o.minAdmins = defaultMinAdmins
-	minAdmins := actions.GetInput("min-admins")
-	if minAdmins != "" {
-		o.minAdmins, _ = strconv.Atoi(minAdmins)
-	}
-
-	requireSelf := actions.GetInput("require-self")
-	if requireSelf != "" {
-		o.requireSelf, _ = strconv.ParseBool(requireSelf)
-	}
-
-	o.github.ThrottleHourlyTokens = defaultTokens
-	throttleHourlyTokens := actions.GetInput("github-hourly-tokens")
-	if throttleHourlyTokens != "" {
-		o.github.ThrottleHourlyTokens, _ = strconv.Atoi(throttleHourlyTokens)
-	}
-
-	o.github.ThrottleAllowBurst = defaultBurst
-	throttleAllowBurst := actions.GetInput("github-allowed-burst")
-	if throttleHourlyTokens != "" {
-		o.github.ThrottleAllowBurst, _ = strconv.Atoi(throttleAllowBurst)
-	}
-
-	o.github.Host = github.DefaultHost
-
-	o.logLevel = logrus.InfoLevel.String()
-	logLevel := actions.GetInput("log-level")
-	if logLevel != "" {
-		o.logLevel = logLevel
-	}
-
-	if err := o.github.Validate(!o.confirm); err != nil {
-		actions.Fatalf(err.Error())
-	}
-
-	if o.minAdmins < 2 {
-		actions.Fatalf("--min-admins=%d must be at least 2", o.minAdmins)
-	}
-
-	if o.maximumDelta > 1 || o.maximumDelta < 0 {
-		actions.Fatalf("--maximum-removal-delta=%f must be a non-negative number less than 1.0", o.maximumDelta)
-	}
-
-	if o.confirm && o.dump != "" {
-		actions.Fatalf("--confirm cannot be used with --dump=%s", o.dump)
-	}
-	if o.config == "" && o.dump == "" {
-		actions.Fatalf("--config-path or --dump required")
-	}
-	if o.config != "" && o.dump != "" {
-		actions.Fatalf("--config-path=%s and --dump=%s cannot both be set", o.config, o.dump)
-	}
-
-	if o.dumpFull && o.dump == "" {
-		actions.Fatalf("--dump-full can't be used without --dump")
-	}
-
-	if o.fixTeamMembers && !o.fixTeams {
-		actions.Fatalf("--fix-team-members requires --fix-teams")
-	}
-
-	if o.fixTeamRepos && !o.fixTeams {
-		actions.Fatalf("--fix-team-repos requires --fix-teams")
-	}
-
-	level, err := logrus.ParseLevel(o.logLevel)
-	if err != nil {
-		actions.Fatalf("--log-level invalid: %s", err.Error())
-	}
-	logrus.SetLevel(level)
-
-	// TODO: get the missing flags
-	// flags.Var(&o.requiredAdmins, "required-admins", "Ensure config specifies these users as admins")
-	// flags.Float64Var(&o.maximumDelta, "maximum-removal-delta", defaultDelta, "Fail if config removes more than this fraction of current members")
-	// flags.BoolVar(&o.ignoreSecretTeams, "ignore-secret-teams", false, "Do not dump or update secret teams if set")
-	// flags.BoolVar(&o.allowRepoArchival, "allow-repo-archival", false, "If set, archiving repos is allowed while updating repos")
-	// flags.BoolVar(&o.allowRepoPublish, "allow-repo-publish", false, "If set, making private repos public is allowed while updating repos")
-	// o.github.AddCustomizedFlags(flags, flagutil.ThrottlerDefaults(defaultTokens, defaultBurst))
 
 	return o
 }
 
 func (o *options) parseArgs(flags *flag.FlagSet, args []string) error {
 	o.requiredAdmins = flagutil.NewStrings()
+	flags.BoolVar(&o.actions, "actions", true, "Run as GitHub Action and collect the flags using Actions syntax, if you want to run as standard command see --actions to false")
+	flags.Var(&o.requiredAdmins, "required-admins", "Ensure config specifies these users as admins")
+	flags.IntVar(&o.minAdmins, "min-admins", defaultMinAdmins, "Ensure config specifies at least this many admins")
+	flags.BoolVar(&o.requireSelf, "require-self", true, "Ensure --github-token-path user is an admin")
+	flags.Float64Var(&o.maximumDelta, "maximum-removal-delta", defaultDelta, "Fail if config removes more than this fraction of current members")
+	flags.StringVar(&o.config, "config-path", "", "Path to org config.yaml")
+	flags.BoolVar(&o.confirm, "confirm", false, "Mutate github if set")
+	flags.IntVar(&o.tokensPerHour, "tokens", defaultTokens, "Throttle hourly token consumption (0 to disable) DEPRECATED: use --github-hourly-tokens")
+	flags.IntVar(&o.tokenBurst, "token-burst", defaultBurst, "Allow consuming a subset of hourly tokens in a short burst. DEPRECATED: use --github-allowed-burst")
+	flags.StringVar(&o.dump, "dump", "", "Output current config of this org if set")
+	flags.BoolVar(&o.dumpFull, "dump-full", false, "Output current config of the org as a valid input config file instead of a snippet")
+	flags.BoolVar(&o.ignoreSecretTeams, "ignore-secret-teams", false, "Do not dump or update secret teams if set")
+	flags.BoolVar(&o.fixOrg, "fix-org", false, "Change org metadata if set")
+	flags.BoolVar(&o.fixOrgMembers, "fix-org-members", false, "Add/remove org members if set")
+	flags.BoolVar(&o.fixTeams, "fix-teams", false, "Create/delete/update teams if set")
+	flags.BoolVar(&o.fixTeamMembers, "fix-team-members", false, "Add/remove team members if set")
+	flags.BoolVar(&o.fixTeamRepos, "fix-team-repos", false, "Add/remove team permissions on repos if set")
+	flags.BoolVar(&o.fixRepos, "fix-repos", false, "Create/update repositories if set")
+	flags.BoolVar(&o.allowRepoArchival, "allow-repo-archival", false, "If set, archiving repos is allowed while updating repos")
+	flags.BoolVar(&o.allowRepoPublish, "allow-repo-publish", false, "If set, making private repos public is allowed while updating repos")
+	flags.StringVar(&o.logLevel, "log-level", logrus.InfoLevel.String(), fmt.Sprintf("Logging level, one of %v", logrus.AllLevels))
 	o.github.AddCustomizedFlags(flags, flagutil.ThrottlerDefaults(defaultTokens, defaultBurst))
 	if err := flags.Parse(args); err != nil {
 		return err
 	}
+
+	if o.actions {
+		o.dump = actions.GetInput("dump")
+		o.config = actions.GetInput("config-path")
+
+		dumpFull := actions.GetInput("dump-full")
+		if dumpFull != "" {
+			o.dumpFull, _ = strconv.ParseBool(dumpFull)
+		}
+
+		confirm := actions.GetInput("confirm")
+		if confirm != "" {
+			o.confirm, _ = strconv.ParseBool(confirm)
+		}
+
+		o.github.TokenPath = actions.GetInput("github-token-path")
+		if o.github.TokenPath == "" {
+			return fmt.Errorf("missing 'github-token-path'")
+		}
+
+		fixOrg := actions.GetInput("fix-org")
+		if fixOrg != "" {
+			o.fixOrg, _ = strconv.ParseBool(fixOrg)
+		}
+
+		fixOrgMembers := actions.GetInput("fix-org-members")
+		if fixOrgMembers != "" {
+			o.fixOrgMembers, _ = strconv.ParseBool(fixOrgMembers)
+		}
+
+		fixTeams := actions.GetInput("fix-teams")
+		if fixTeams != "" {
+			o.fixTeams, _ = strconv.ParseBool(fixTeams)
+		}
+
+		fixTeamMembers := actions.GetInput("fix-teams-members")
+		if fixTeamMembers != "" {
+			o.fixTeamMembers, _ = strconv.ParseBool(fixTeamMembers)
+		}
+
+		fixTeamRepos := actions.GetInput("fix-team-repos")
+		if fixTeamRepos != "" {
+			o.fixTeamRepos, _ = strconv.ParseBool(fixTeamRepos)
+		}
+
+		fixRepos := actions.GetInput("fix-repos")
+		if fixRepos != "" {
+			o.fixRepos, _ = strconv.ParseBool(fixRepos)
+		}
+
+		o.minAdmins = defaultMinAdmins
+		minAdmins := actions.GetInput("min-admins")
+		if minAdmins != "" {
+			o.minAdmins, _ = strconv.Atoi(minAdmins)
+		}
+
+		requireSelf := actions.GetInput("require-self")
+		if requireSelf != "" {
+			o.requireSelf, _ = strconv.ParseBool(requireSelf)
+		}
+
+		o.github.ThrottleHourlyTokens = defaultTokens
+		throttleHourlyTokens := actions.GetInput("github-hourly-tokens")
+		if throttleHourlyTokens != "" {
+			o.github.ThrottleHourlyTokens, _ = strconv.Atoi(throttleHourlyTokens)
+		}
+
+		o.github.ThrottleAllowBurst = defaultBurst
+		throttleAllowBurst := actions.GetInput("github-allowed-burst")
+		if throttleHourlyTokens != "" {
+			o.github.ThrottleAllowBurst, _ = strconv.Atoi(throttleAllowBurst)
+		}
+
+		o.github.Host = github.DefaultHost
+
+		o.logLevel = logrus.InfoLevel.String()
+		logLevel := actions.GetInput("log-level")
+		if logLevel != "" {
+			o.logLevel = logLevel
+		}
+	}
+
+	if err := o.github.Validate(!o.confirm); err != nil {
+		return fmt.Errorf(err.Error())
+	}
+
+	if o.minAdmins < 2 {
+		return fmt.Errorf("--min-admins=%d must be at least 2", o.minAdmins)
+	}
+
+	if o.maximumDelta > 1 || o.maximumDelta < 0 {
+		return fmt.Errorf("--maximum-removal-delta=%f must be a non-negative number less than 1.0", o.maximumDelta)
+	}
+
+	if o.confirm && o.dump != "" {
+		return fmt.Errorf("--confirm cannot be used with --dump=%s", o.dump)
+	}
+	if o.config == "" && o.dump == "" {
+		return fmt.Errorf("--config-path or --dump required")
+	}
+	if o.config != "" && o.dump != "" {
+		return fmt.Errorf("--config-path=%s and --dump=%s cannot both be set", o.config, o.dump)
+	}
+
+	if o.dumpFull && o.dump == "" {
+		return fmt.Errorf("--dump-full can't be used without --dump")
+	}
+
+	if o.fixTeamMembers && !o.fixTeams {
+		return fmt.Errorf("--fix-team-members requires --fix-teams")
+	}
+
+	if o.fixTeamRepos && !o.fixTeams {
+		return fmt.Errorf("--fix-team-repos requires --fix-teams")
+	}
+
+	level, err := logrus.ParseLevel(o.logLevel)
+	if err != nil {
+		return fmt.Errorf("--log-level invalid: %s", err.Error())
+	}
+	logrus.SetLevel(level)
 
 	return nil
 }

--- a/main.go
+++ b/main.go
@@ -42,6 +42,29 @@ const (
 	defaultDelta     = 0.25
 	defaultTokens    = 300
 	defaultBurst     = 100
+
+	// Flags.
+	flagActions           = "actions"
+	flagRequiredAdmins    = "required-admins"
+	flagMinAdmins         = "min-admins"
+	flagRequireSelf       = "require-self"
+	flagMaxRemovalDelta   = "maximum-removal-delta"
+	flagConfigPath        = "config-path"
+	flagConfirm           = "confirm"
+	flagTokens            = "tokens"
+	flagTokenBurst        = "token-burst"
+	flagDump              = "dump"
+	flagDumpFull          = "dump-full"
+	flagIgnoreSecretTeams = "ignore-secret-teams"
+	flagFixOrg            = "fix-org"
+	flagFixOrgMembers     = "fix-org-members"
+	flagFixTeams          = "fix-teams"
+	flagFixTeamMembers    = "fix-team-members"
+	flagFixTeamRepos      = "fix-team-repos"
+	flagFixRepos          = "fix-repos"
+	flagAllowRepoArchival = "allow-repo-archival"
+	flagAllowRepoPublish  = "allow-repo-publish"
+	flagLogLevel          = "log-level"
 )
 
 type options struct {
@@ -86,146 +109,146 @@ func (o *options) parseArgs(flags *flag.FlagSet, args []string) error {
 
 	flags.BoolVar(
 		&o.actions,
-		"actions",
+		flagActions,
 		true,
 		"Run as GitHub Action and collect the flags using Actions syntax, if you want to run as standard command see --actions to false",
 	)
 
 	flags.Var(
 		&o.requiredAdmins,
-		"required-admins",
+		flagRequiredAdmins,
 		"Ensure config specifies these users as admins",
 	)
 
 	flags.IntVar(
 		&o.minAdmins,
-		"min-admins",
+		flagMinAdmins,
 		defaultMinAdmins,
 		"Ensure config specifies at least this many admins",
 	)
 
 	flags.BoolVar(
 		&o.requireSelf,
-		"require-self",
+		flagRequireSelf,
 		true,
 		"Ensure --github-token-path user is an admin",
 	)
 
 	flags.Float64Var(
 		&o.maximumDelta,
-		"maximum-removal-delta",
+		flagMaxRemovalDelta,
 		defaultDelta,
 		"Fail if config removes more than this fraction of current members",
 	)
 
 	flags.StringVar(
 		&o.config,
-		"config-path",
+		flagConfigPath,
 		"",
 		"Path to org config.yaml",
 	)
 
 	flags.BoolVar(
 		&o.confirm,
-		"confirm",
+		flagConfirm,
 		false,
 		"Mutate github if set",
 	)
 
 	flags.IntVar(
 		&o.tokensPerHour,
-		"tokens",
+		flagTokens,
 		defaultTokens,
 		"Throttle hourly token consumption (0 to disable) DEPRECATED: use --github-hourly-tokens",
 	)
 
 	flags.IntVar(
 		&o.tokenBurst,
-		"token-burst",
+		flagTokenBurst,
 		defaultBurst,
 		"Allow consuming a subset of hourly tokens in a short burst. DEPRECATED: use --github-allowed-burst",
 	)
 
 	flags.StringVar(
 		&o.dump,
-		"dump",
+		flagDump,
 		"",
 		"Output current config of this org if set",
 	)
 
 	flags.BoolVar(
 		&o.dumpFull,
-		"dump-full",
+		flagDumpFull,
 		false,
 		"Output current config of the org as a valid input config file instead of a snippet",
 	)
 
 	flags.BoolVar(
 		&o.ignoreSecretTeams,
-		"ignore-secret-teams",
+		flagIgnoreSecretTeams,
 		false,
 		"Do not dump or update secret teams if set",
 	)
 
 	flags.BoolVar(
 		&o.fixOrg,
-		"fix-org",
+		flagFixOrg,
 		false,
 		"Change org metadata if set",
 	)
 
 	flags.BoolVar(
 		&o.fixOrgMembers,
-		"fix-org-members",
+		flagFixOrgMembers,
 		false,
 		"Add/remove org members if set",
 	)
 
 	flags.BoolVar(
 		&o.fixTeams,
-		"fix-teams",
+		flagFixTeams,
 		false,
 		"Create/delete/update teams if set",
 	)
 
 	flags.BoolVar(
 		&o.fixTeamMembers,
-		"fix-team-members",
+		flagFixTeamMembers,
 		false,
 		"Add/remove team members if set",
 	)
 
 	flags.BoolVar(
 		&o.fixTeamRepos,
-		"fix-team-repos",
+		flagFixTeamRepos,
 		false,
 		"Add/remove team permissions on repos if set",
 	)
 
 	flags.BoolVar(
 		&o.fixRepos,
-		"fix-repos",
+		flagFixRepos,
 		false,
 		"Create/update repositories if set",
 	)
 
 	flags.BoolVar(
 		&o.allowRepoArchival,
-		"allow-repo-archival",
+		flagAllowRepoArchival,
 		false,
 		"If set, archiving repos is allowed while updating repos",
 	)
 
 	flags.BoolVar(
 		&o.allowRepoPublish,
-		"allow-repo-publish",
+		flagAllowRepoPublish,
 		false,
 		"If set, making private repos public is allowed while updating repos",
 	)
 
 	flags.StringVar(
 		&o.logLevel,
-		"log-level",
+		flagLogLevel,
 		logrus.InfoLevel.String(),
 		fmt.Sprintf("Logging level, one of %v", logrus.AllLevels),
 	)
@@ -236,71 +259,74 @@ func (o *options) parseArgs(flags *flag.FlagSet, args []string) error {
 	}
 
 	if o.actions {
-		o.dump = actions.GetInput("dump")
-		o.config = actions.GetInput("config-path")
+		o.dump = actions.GetInput(flagDump)
+		o.config = actions.GetInput(flagConfigPath)
 
-		dumpFull := actions.GetInput("dump-full")
+		dumpFull := actions.GetInput(flagDumpFull)
 		if dumpFull != "" {
 			o.dumpFull, _ = strconv.ParseBool(dumpFull)
 		}
 
-		confirm := actions.GetInput("confirm")
+		confirm := actions.GetInput(flagConfirm)
 		if confirm != "" {
 			o.confirm, _ = strconv.ParseBool(confirm)
 		}
 
+		// TODO(flags): Consider parameterizing flag.
 		o.github.TokenPath = actions.GetInput("github-token-path")
 		if o.github.TokenPath == "" {
 			return fmt.Errorf("missing 'github-token-path'")
 		}
 
-		fixOrg := actions.GetInput("fix-org")
+		fixOrg := actions.GetInput(flagFixOrg)
 		if fixOrg != "" {
 			o.fixOrg, _ = strconv.ParseBool(fixOrg)
 		}
 
-		fixOrgMembers := actions.GetInput("fix-org-members")
+		fixOrgMembers := actions.GetInput(flagFixOrgMembers)
 		if fixOrgMembers != "" {
 			o.fixOrgMembers, _ = strconv.ParseBool(fixOrgMembers)
 		}
 
-		fixTeams := actions.GetInput("fix-teams")
+		fixTeams := actions.GetInput(flagFixTeams)
 		if fixTeams != "" {
 			o.fixTeams, _ = strconv.ParseBool(fixTeams)
 		}
 
-		fixTeamMembers := actions.GetInput("fix-teams-members")
+		fixTeamMembers := actions.GetInput(flagFixTeamMembers)
 		if fixTeamMembers != "" {
 			o.fixTeamMembers, _ = strconv.ParseBool(fixTeamMembers)
 		}
 
-		fixTeamRepos := actions.GetInput("fix-team-repos")
+		fixTeamRepos := actions.GetInput(flagFixTeamRepos)
 		if fixTeamRepos != "" {
 			o.fixTeamRepos, _ = strconv.ParseBool(fixTeamRepos)
 		}
 
-		fixRepos := actions.GetInput("fix-repos")
+		fixRepos := actions.GetInput(flagFixRepos)
 		if fixRepos != "" {
 			o.fixRepos, _ = strconv.ParseBool(fixRepos)
 		}
 
 		o.minAdmins = defaultMinAdmins
-		minAdmins := actions.GetInput("min-admins")
+		minAdmins := actions.GetInput(flagMinAdmins)
 		if minAdmins != "" {
 			o.minAdmins, _ = strconv.Atoi(minAdmins)
 		}
 
-		requireSelf := actions.GetInput("require-self")
+		requireSelf := actions.GetInput(flagRequireSelf)
 		if requireSelf != "" {
 			o.requireSelf, _ = strconv.ParseBool(requireSelf)
 		}
 
+		// TODO(flags): Consider parameterizing flag.
 		o.github.ThrottleHourlyTokens = defaultTokens
 		throttleHourlyTokens := actions.GetInput("github-hourly-tokens")
 		if throttleHourlyTokens != "" {
 			o.github.ThrottleHourlyTokens, _ = strconv.Atoi(throttleHourlyTokens)
 		}
 
+		// TODO(flags): Consider parameterizing flag.
 		o.github.ThrottleAllowBurst = defaultBurst
 		throttleAllowBurst := actions.GetInput("github-allowed-burst")
 		if throttleHourlyTokens != "" {
@@ -310,7 +336,7 @@ func (o *options) parseArgs(flags *flag.FlagSet, args []string) error {
 		o.github.Host = github.DefaultHost
 
 		o.logLevel = logrus.InfoLevel.String()
-		logLevel := actions.GetInput("log-level")
+		logLevel := actions.GetInput(flagLogLevel)
 		if logLevel != "" {
 			o.logLevel = logLevel
 		}

--- a/main.go
+++ b/main.go
@@ -83,27 +83,153 @@ func parseOptions() options {
 
 func (o *options) parseArgs(flags *flag.FlagSet, args []string) error {
 	o.requiredAdmins = flagutil.NewStrings()
-	flags.BoolVar(&o.actions, "actions", true, "Run as GitHub Action and collect the flags using Actions syntax, if you want to run as standard command see --actions to false")
-	flags.Var(&o.requiredAdmins, "required-admins", "Ensure config specifies these users as admins")
-	flags.IntVar(&o.minAdmins, "min-admins", defaultMinAdmins, "Ensure config specifies at least this many admins")
-	flags.BoolVar(&o.requireSelf, "require-self", true, "Ensure --github-token-path user is an admin")
-	flags.Float64Var(&o.maximumDelta, "maximum-removal-delta", defaultDelta, "Fail if config removes more than this fraction of current members")
-	flags.StringVar(&o.config, "config-path", "", "Path to org config.yaml")
-	flags.BoolVar(&o.confirm, "confirm", false, "Mutate github if set")
-	flags.IntVar(&o.tokensPerHour, "tokens", defaultTokens, "Throttle hourly token consumption (0 to disable) DEPRECATED: use --github-hourly-tokens")
-	flags.IntVar(&o.tokenBurst, "token-burst", defaultBurst, "Allow consuming a subset of hourly tokens in a short burst. DEPRECATED: use --github-allowed-burst")
-	flags.StringVar(&o.dump, "dump", "", "Output current config of this org if set")
-	flags.BoolVar(&o.dumpFull, "dump-full", false, "Output current config of the org as a valid input config file instead of a snippet")
-	flags.BoolVar(&o.ignoreSecretTeams, "ignore-secret-teams", false, "Do not dump or update secret teams if set")
-	flags.BoolVar(&o.fixOrg, "fix-org", false, "Change org metadata if set")
-	flags.BoolVar(&o.fixOrgMembers, "fix-org-members", false, "Add/remove org members if set")
-	flags.BoolVar(&o.fixTeams, "fix-teams", false, "Create/delete/update teams if set")
-	flags.BoolVar(&o.fixTeamMembers, "fix-team-members", false, "Add/remove team members if set")
-	flags.BoolVar(&o.fixTeamRepos, "fix-team-repos", false, "Add/remove team permissions on repos if set")
-	flags.BoolVar(&o.fixRepos, "fix-repos", false, "Create/update repositories if set")
-	flags.BoolVar(&o.allowRepoArchival, "allow-repo-archival", false, "If set, archiving repos is allowed while updating repos")
-	flags.BoolVar(&o.allowRepoPublish, "allow-repo-publish", false, "If set, making private repos public is allowed while updating repos")
-	flags.StringVar(&o.logLevel, "log-level", logrus.InfoLevel.String(), fmt.Sprintf("Logging level, one of %v", logrus.AllLevels))
+
+	flags.BoolVar(
+		&o.actions,
+		"actions",
+		true,
+		"Run as GitHub Action and collect the flags using Actions syntax, if you want to run as standard command see --actions to false",
+	)
+
+	flags.Var(
+		&o.requiredAdmins,
+		"required-admins",
+		"Ensure config specifies these users as admins",
+	)
+
+	flags.IntVar(
+		&o.minAdmins,
+		"min-admins",
+		defaultMinAdmins,
+		"Ensure config specifies at least this many admins",
+	)
+
+	flags.BoolVar(
+		&o.requireSelf,
+		"require-self",
+		true,
+		"Ensure --github-token-path user is an admin",
+	)
+
+	flags.Float64Var(
+		&o.maximumDelta,
+		"maximum-removal-delta",
+		defaultDelta,
+		"Fail if config removes more than this fraction of current members",
+	)
+
+	flags.StringVar(
+		&o.config,
+		"config-path",
+		"",
+		"Path to org config.yaml",
+	)
+
+	flags.BoolVar(
+		&o.confirm,
+		"confirm",
+		false,
+		"Mutate github if set",
+	)
+
+	flags.IntVar(
+		&o.tokensPerHour,
+		"tokens",
+		defaultTokens,
+		"Throttle hourly token consumption (0 to disable) DEPRECATED: use --github-hourly-tokens",
+	)
+
+	flags.IntVar(
+		&o.tokenBurst,
+		"token-burst",
+		defaultBurst,
+		"Allow consuming a subset of hourly tokens in a short burst. DEPRECATED: use --github-allowed-burst",
+	)
+
+	flags.StringVar(
+		&o.dump,
+		"dump",
+		"",
+		"Output current config of this org if set",
+	)
+
+	flags.BoolVar(
+		&o.dumpFull,
+		"dump-full",
+		false,
+		"Output current config of the org as a valid input config file instead of a snippet",
+	)
+
+	flags.BoolVar(
+		&o.ignoreSecretTeams,
+		"ignore-secret-teams",
+		false,
+		"Do not dump or update secret teams if set",
+	)
+
+	flags.BoolVar(
+		&o.fixOrg,
+		"fix-org",
+		false,
+		"Change org metadata if set",
+	)
+
+	flags.BoolVar(
+		&o.fixOrgMembers,
+		"fix-org-members",
+		false,
+		"Add/remove org members if set",
+	)
+
+	flags.BoolVar(
+		&o.fixTeams,
+		"fix-teams",
+		false,
+		"Create/delete/update teams if set",
+	)
+
+	flags.BoolVar(
+		&o.fixTeamMembers,
+		"fix-team-members",
+		false,
+		"Add/remove team members if set",
+	)
+
+	flags.BoolVar(
+		&o.fixTeamRepos,
+		"fix-team-repos",
+		false,
+		"Add/remove team permissions on repos if set",
+	)
+
+	flags.BoolVar(
+		&o.fixRepos,
+		"fix-repos",
+		false,
+		"Create/update repositories if set",
+	)
+
+	flags.BoolVar(
+		&o.allowRepoArchival,
+		"allow-repo-archival",
+		false,
+		"If set, archiving repos is allowed while updating repos",
+	)
+
+	flags.BoolVar(
+		&o.allowRepoPublish,
+		"allow-repo-publish",
+		false,
+		"If set, making private repos public is allowed while updating repos",
+	)
+
+	flags.StringVar(
+		&o.logLevel,
+		"log-level",
+		logrus.InfoLevel.String(),
+		fmt.Sprintf("Logging level, one of %v", logrus.AllLevels),
+	)
+
 	o.github.AddCustomizedFlags(flags, flagutil.ThrottlerDefaults(defaultTokens, defaultBurst))
 	if err := flags.Parse(args); err != nil {
 		return err

--- a/main_test.go
+++ b/main_test.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"errors"
+	"flag"
 	"fmt"
 	"reflect"
 	"sort"
@@ -33,6 +34,167 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/yaml"
 )
+
+func TestOptions(t *testing.T) {
+	cases := []struct {
+		name     string
+		args     []string
+		expected *options
+	}{
+		{
+			name: "missing --config",
+			args: []string{},
+		},
+		{
+			name: "bad --github-endpoint",
+			args: []string{"--config-path=foo", "--github-endpoint=ht!tp://:dumb"},
+		},
+		{
+			name: "--minAdmins too low",
+			args: []string{"--config-path=foo", "--min-admins=1"},
+		},
+		{
+			name: "--maximum-removal-delta too high",
+			args: []string{"--config-path=foo", "--maximum-removal-delta=1.1"},
+		},
+		{
+			name: "--maximum-removal-delta too low",
+			args: []string{"--config-path=foo", "--maximum-removal-delta=-0.1"},
+		},
+		{
+			name: "reject --dump-full-config without --dump",
+			args: []string{"--config-path=foo", "--dump-full-config"},
+		},
+		{
+			name: "maximal delta",
+			args: []string{"--config-path=foo", "--maximum-removal-delta=1", "--actions=false"},
+			expected: &options{
+				config:        "foo",
+				minAdmins:     defaultMinAdmins,
+				requireSelf:   true,
+				maximumDelta:  1,
+				tokensPerHour: defaultTokens,
+				tokenBurst:    defaultBurst,
+				logLevel:      "info",
+			},
+		},
+		{
+			name: "minimal delta",
+			args: []string{"--config-path=foo", "--maximum-removal-delta=0", "--actions=false"},
+			expected: &options{
+				config:        "foo",
+				minAdmins:     defaultMinAdmins,
+				requireSelf:   true,
+				maximumDelta:  0,
+				tokensPerHour: defaultTokens,
+				tokenBurst:    defaultBurst,
+				logLevel:      "info",
+			},
+		},
+		{
+			name: "minimal admins",
+			args: []string{"--config-path=foo", "--min-admins=2", "--actions=false"},
+			expected: &options{
+				config:        "foo",
+				minAdmins:     2,
+				requireSelf:   true,
+				maximumDelta:  defaultDelta,
+				tokensPerHour: defaultTokens,
+				tokenBurst:    defaultBurst,
+				logLevel:      "info",
+			},
+		},
+		{
+			name: "reject burst > tokens",
+			args: []string{"--config-path=foo", "--tokens=10", "--token-burst=11"},
+		},
+		{
+			name: "reject dump and confirm",
+			args: []string{"--confirm", "--dump=frogger"},
+		},
+		{
+			name: "reject dump and config-path",
+			args: []string{"--config-path=foo", "--dump=frogger"},
+		},
+		{
+			name: "reject --fix-team-members without --fix-teams",
+			args: []string{"--config-path=foo", "--fix-team-members"},
+		},
+		{
+			name: "allow legacy disabled throttle",
+			args: []string{"--config-path=foo", "--tokens=0", "--actions=false"},
+			expected: &options{
+				config:       "foo",
+				minAdmins:    defaultMinAdmins,
+				requireSelf:  true,
+				maximumDelta: defaultDelta,
+				tokenBurst:   defaultBurst,
+				logLevel:     "info",
+			},
+		},
+		{
+			name: "allow dump without config",
+			args: []string{"--dump=frogger", "--actions=false"},
+			expected: &options{
+				minAdmins:     defaultMinAdmins,
+				requireSelf:   true,
+				maximumDelta:  defaultDelta,
+				tokensPerHour: defaultTokens,
+				tokenBurst:    defaultBurst,
+				dump:          "frogger",
+				logLevel:      "info",
+			},
+		},
+		{
+			name: "minimal",
+			args: []string{"--config-path=foo", "--actions=false"},
+			expected: &options{
+				config:        "foo",
+				minAdmins:     defaultMinAdmins,
+				requireSelf:   true,
+				maximumDelta:  defaultDelta,
+				tokensPerHour: defaultTokens,
+				tokenBurst:    defaultBurst,
+				logLevel:      "info",
+			},
+		},
+		{
+			name: "full",
+			args: []string{"--actions=false", "--config-path=foo", "--github-token-path=bar", "--github-endpoint=weird://url", "--confirm=true", "--require-self=false", "--tokens=5", "--token-burst=2", "--dump=", "--fix-org", "--fix-org-members", "--fix-teams", "--fix-team-members", "--log-level=debug"},
+			expected: &options{
+				config:         "foo",
+				confirm:        true,
+				requireSelf:    false,
+				minAdmins:      defaultMinAdmins,
+				maximumDelta:   defaultDelta,
+				tokensPerHour:  5,
+				tokenBurst:     2,
+				fixOrg:         true,
+				fixOrgMembers:  true,
+				fixTeams:       true,
+				fixTeamMembers: true,
+				logLevel:       "debug",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			flags := flag.NewFlagSet(tc.name, flag.ContinueOnError)
+			var actual options
+			err := actual.parseArgs(flags, tc.args)
+			actual.github = flagutil.GitHubOptions{}
+			switch {
+			case err == nil && tc.expected == nil:
+				t.Errorf("%s: failed to return an error", tc.name)
+			case err != nil && tc.expected != nil:
+				t.Errorf("%s: unexpected error: %v", tc.name, err)
+			case tc.expected != nil && !reflect.DeepEqual(*tc.expected, actual):
+				t.Errorf("%s: got incorrect options: %v", tc.name, cmp.Diff(actual, *tc.expected, cmp.AllowUnexported(options{}, flagutil.Strings{}, flagutil.GitHubOptions{})))
+			}
+		})
+	}
+}
 
 type fakeClient struct {
 	orgMembers sets.String


### PR DESCRIPTION
i was not happy to not be able to run locally as well, then I think in a way to be able to run as GitHub action and as a standard command line.

There is a new flag that is always set to `true` that turns to read the parameters from GitHub action, if you set that to false you will need to pass the parameters as normal flags

now both can be used