### PR TITLE
Update code to run as well on GH actions

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,4 +1,4 @@
-defaultBaseImage: ghcr.io/chainguard-dev/apko:v0.1.2@sha256:5504f2a95018e3d8a52d80d9e1a128c6ea337581808ff9fe96f5628ce2336350
+defaultBaseImage: gcr.io/distroless/base-debian10
 
 builds:
 - id: peribolos

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -47,7 +47,9 @@ func New(o *options.Options) *cobra.Command {
 		},
 	}
 
-	o.AddFlags(cmd)
+	if !o.UsingActions {
+		o.AddFlags(cmd)
+	}
 
 	// Add sub-commands.
 	cmd.AddCommand(version.Version())

--- a/main.go
+++ b/main.go
@@ -17,6 +17,8 @@ limitations under the License.
 package main
 
 import (
+	"fmt"
+
 	"github.com/sirupsen/logrus"
 
 	"k8s.io/test-infra/prow/logrusutil"
@@ -29,6 +31,14 @@ func main() {
 	logrusutil.ComponentInit()
 
 	o := options.New()
+	if o.UsingActions {
+		fmt.Println(">>> Running in GitHub Actions environment <<<")
+		err := o.ParseFromAction()
+		if err != nil {
+			fmt.Println(err.Error())
+			logrus.WithError(err).Fatal("an error occurred while running peribolos in GitHub Action mode")
+		}
+	}
 	if err := cmd.New(&o).Execute(); err != nil {
 		logrus.WithError(err).Fatal("an error occurred while running peribolos")
 	}


### PR DESCRIPTION
- looks like the dependency code need somehow a shell, so reverting back to a distroless image with a shell available

from https://github.com/kingdom-tower/testing/runs/5586031227?check_suite_focus=true
```
Error: unknown command "/bin/sh" for ""
Run ' --help' for usage.
```

- also a bit hacky but works in both cases, running locally or in action
for actions see https://github.com/kingdom-tower/testing/actions/runs/1998915258 and https://github.com/kingdom-tower/testing/runs/5586673297?check_suite_focus=true

running locally 

```
$ ./peribolos --dump kingdom-tower --github-token-path=token
{"client":"github","component":"unset","file":"/Users/cpanato/code/pkg/mod/k8s.io/test-infra@v0.0.0-20211221011455-3d87616db8ae/prow/github/client.go:889","func":"k8s.io/test-infra/prow/github.(*client).log","level":"info","msg":"Throttle(300, 100, *)","severity":"info","time":"2022-03-17T14:39:35+01:00"}
{"client":"github","component":"unset","file":"/Users/cpanato/code/pkg/mod/k8s.io/test-infra@v0.0.0-20211221011455-3d87616db8ae/prow/github/client.go:889","func":"k8s.io/test-infra/prow/github.(*client).log","level":"info","msg":"GetOrg(kingdom-tower)","severity":"info","time":"2022-03-17T14:39:35+01:00"}
{"client":"github","component":"unset","file":"/Users/cpanato/code/pkg/mod/k8s.io/test-infra@v0.0.0-20211221011455-3d87616db8ae/prow/github/client.go:889","func":"k8s.io/test-infra/prow/github.(*client).log","level":"info","msg":"User()","severity":"info","time":"2022-03-17T14:39:36+01:00"}
{"client":"github","component":"unset","file":"/Users/cpanato/code/pkg/mod/k8s.io/test-infra@v0.0.0-20211221011455-3d87616db8ae/prow/github/client.go:889","func":"k8s.io/test-infra/prow/github.(*client).log","level":"info","msg":"ListOrgMembers(kingdom-tower, admin)","severity":"info","time":"2022-03-17T14:39:36+01:00"}
{"client":"github","component":"unset","file":"/Users/cpanato/code/pkg/mod/k8s.io/test-infra@v0.0.0-20211221011455-3d87616db8ae/prow/github/client.go:889","func":"k8s.io/test-infra/prow/github.(*client).log","level":"info","msg":"ListOrgMembers(kingdom-tower, member)","severity":"info","time":"2022-03-17T14:39:36+01:00"}
{"client":"github","component":"unset","file":"/Users/cpanato/code/pkg/mod/k8s.io/test-infra@v0.0.0-20211221011455-3d87616db8ae/prow/github/client.go:889","func":"k8s.io/test-infra/prow/github.(*client).log","level":"info","msg":"ListTeams(kingdom-tower)","severity":"info","time":"2022-03-17T14:39:36+01:00"}
{"client":"github","component":"unset","file":"/Users/cpanato/code/pkg/mod/k8s.io/test-infra@v0.0.0-20211221011455-3d87616db8ae/prow/github/client.go:889","func":"k8s.io/test-infra/prow/github.(*client).log","level":"info","msg":"ListTeamMembers(5437372, maintainer)","severity":"info","time":"2022-03-17T14:39:36+01:00"}
{"client":"github","component":"unset","file":"/Users/cpanato/code/pkg/mod/k8s.io/test-infra@v0.0.0-20211221011455-3d87616db8ae/prow/github/client.go:889","func":"k8s.io/test-infra/prow/github.(*client).log","level":"info","msg":"ListTeamMembers(5437372, member)","severity":"info","time":"2022-03-17T14:39:37+01:00"}
{"client":"github","component":"unset","file":"/Users/cpanato/code/pkg/mod/k8s.io/test-infra@v0.0.0-20211221011455-3d87616db8ae/prow/github/client.go:889","func":"k8s.io/test-infra/prow/github.(*client).log","level":"info","msg":"ListTeamRepos(5437372)","severity":"info","time":"2022-03-17T14:39:37+01:00"}
{"client":"github","component":"unset","file":"/Users/cpanato/code/pkg/mod/k8s.io/test-infra@v0.0.0-20211221011455-3d87616db8ae/prow/github/client.go:889","func":"k8s.io/test-infra/prow/github.(*client).log","level":"info","msg":"ListTeamMembers(5437468, maintainer)","severity":"info","time":"2022-03-17T14:39:37+01:00"}
{"client":"github","component":"unset","file":"/Users/cpanato/code/pkg/mod/k8s.io/test-infra@v0.0.0-20211221011455-3d87616db8ae/prow/github/client.go:889","func":"k8s.io/test-infra/prow/github.(*client).log","level":"info","msg":"ListTeamMembers(5437468, member)","severity":"info","time":"2022-03-17T14:39:37+01:00"}
....
```
