### PR TITLE
Fix and updates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,5 +47,4 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
 
     - run: |
-        make ko-build
-        make sign-images
+        make build-sign-images

--- a/Makefile
+++ b/Makefile
@@ -13,11 +13,9 @@ ko-build:
 ko-local:
 	ko build --local --base-import-paths github.com/relengfam/peribolos
 
-imagerefs := $(shell cat imagerefs)
-sign-refs := $(foreach ref,$(imagerefs),$(ref))
-.PHONY: sign-images
-sign-images:
-	cosign sign -a GIT_TAG=$(GIT_TAG) -a GIT_HASH=$(GIT_HASH) $(sign-refs)
+.PHONY: build-sign-images
+build-sign-images: ko-build
+	GIT_HASH=$(GIT_HASH) GIT_TAG=$(GIT_TAG) ./scripts/sign-images.sh
 
 # kubernetes/org make targets
 # TODO(k-org): Remove once integrated into peribolos
@@ -45,10 +43,6 @@ MERGED_CONFIG := $(OUTPUT_DIR)/gen-config.yaml
 .PHONY: clean
 clean:
 	rm -rf $(OUTPUT_DIR)
-
-.PHONY: build
-build:
-	go build ./...
 
 .PHONY: merge
 merge: $(MERGE_CMD)

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ SHELL := /usr/bin/env bash
 GITHUB_TOKEN_PATH ?=
 
 # intentionally hardcoded list to ensure it's high friction to remove someone
-ADMINS = cblecker fejta idvoretskyi mrbobbytables nikhita spiffxp
+ADMINS = cpanato justaugustus
 ORGS = $(shell find ./config -type d -mindepth 1 -maxdepth 1 | cut -d/ -f3)
 
 # use absolute path to ./_output, which is .gitignored

--- a/admin/update.sh
+++ b/admin/update.sh
@@ -22,12 +22,8 @@ REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)
 readonly REPO_ROOT
 
 readonly admins=(
-  cblecker
-  fejta
-  idvoretskyi
-  mrbobbytables
-  nikhita
-  spiffxp
+  cpanato
+  justaugustus
 )
 
 cd "${REPO_ROOT}"

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -54,6 +54,7 @@ func New(o *root.Options) *cobra.Command {
 	// Add sub-commands.
 	cmd.AddCommand(Merge())
 	cmd.AddCommand(version.Version())
+
 	return cmd
 }
 

--- a/config/uwu-tools/org.yaml
+++ b/config/uwu-tools/org.yaml
@@ -1,0 +1,15 @@
+admins:
+- auggie-bot
+- cpanato
+- justaugustus
+- sethmccombs
+billing_email: fake@example.com
+company: ""
+default_repository_permission: read
+description: ""
+email: ""
+has_organization_projects: true
+has_repository_projects: true
+location: ""
+members_can_create_repositories: true
+name: ""

--- a/options/merge/flags.go
+++ b/options/merge/flags.go
@@ -20,11 +20,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/ghodss/yaml"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-
-	"k8s.io/test-infra/prow/config/org"
 )
 
 type flagMap map[string]string
@@ -78,22 +75,8 @@ func (o *Options) AddFlags(cmd *cobra.Command) {
 
 	for _, a := range cmd.Flags().Args() {
 		logrus.Print("Extra", a)
-		o.Orgs.Set(a)
+		_ = o.Orgs.Set(a)
 	}
-
-	// TODO(merge): Move into mergeCmd()
-	cfg, err := loadOrgs(*o)
-	if err != nil {
-		logrus.Fatalf("Failed to load orgs: %v", err)
-	}
-	pc := org.FullConfig{
-		Orgs: cfg,
-	}
-	out, err := yaml.Marshal(pc)
-	if err != nil {
-		logrus.Fatalf("Failed to marshal orgs: %v", err)
-	}
-	fmt.Println(string(out))
 }
 
 func parseKeyValue(s string) (string, string) {

--- a/options/merge/merge.go
+++ b/options/merge/merge.go
@@ -40,7 +40,6 @@ func NewOptions() *Options {
 		Orgs: flagMap{},
 	}
 
-	o.Validate()
 	return o
 }
 

--- a/scripts/sign-images.sh
+++ b/scripts/sign-images.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+# Copyright RelEngFam Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+: "${GIT_HASH:?Environment variable empty or not defined.}"
+: "${GIT_TAG:?Environment variable empty or not defined.}"
+
+export COSIGN_EXPERIMENTAL=true
+
+if [[ ! -f imagerefs ]]; then
+    echo "imagerefs not found"
+    exit 1
+fi
+
+echo "Signing cosign images using Keyless..."
+
+cosign sign -a GIT_TAG="$GIT_TAG" -a GIT_HASH="$GIT_HASH" "$(cat imagerefs)"


### PR DESCRIPTION
- update build sign image
- fix the merge command

now it does not output the `{}`

Partially addresses #78.

```
$ ./_output/bin/peribolos --help
Usage:
   [flags]
   [command]

Available Commands:
  completion  Generate the autocompletion script for the specified shell
  help        Help about any command
  merge
  version     Prints the version

Flags:
...
```

and also output the flags for the merge command

```
$ ./_output/bin/peribolos merge --help
Usage:
   merge [flags]

Flags:
  -h, --help                                 help for merge
      --ignore-teams                         Never configure teams
      --merge-teams                          Merge team-name/team.yaml files in each org.yaml dir
      --org-part Type() is not implemented   Each instance adds an org-name=org.yaml part
```

